### PR TITLE
Remove `!important` styles for fonts

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -98,8 +98,8 @@ atom-text-editor {
 // Syntax styles
 .syntax--comment {
   color: @gray;
-  font-style: normal !important;
-  font-family: 'Monaco', sans-serif !important;
+  font-style: normal;
+  font-family: 'Monaco', sans-serif;
 }
 
 .syntax--keyword {


### PR DESCRIPTION
Using `!important` causes conflicts with user's
custom configurations.

Fix #2 & Fix #1